### PR TITLE
feat: support opacity in edge label background

### DIFF
--- a/packages/graphin/src/typings/type.ts
+++ b/packages/graphin/src/typings/type.ts
@@ -267,6 +267,10 @@ export interface EdgeStyle {
          * @description 6
          */
         radius?: number;
+        /**
+         *  @description 透明度，默认值为 1；
+         */
+        opacity: number;
       };
     } & CommondAttrsStyle
   >;


### PR DESCRIPTION
Example with a blue background

Opacity = 1 (default)
![image](https://user-images.githubusercontent.com/2861371/145378053-ac2b6e2d-529e-4fb5-bf78-7f2e28f1d814.png)


Opacity = 0.2
![image](https://user-images.githubusercontent.com/2861371/145377837-6639f0e1-d7e4-4d13-affa-87b1607ff6b6.png)

Upstream: https://github.com/antvis/Graphin/pull/335