### PR TITLE
Bump versions `tag-2.6.7-siren.8` due to changes on G6

### DIFF
--- a/packages/graphin-components/package.json
+++ b/packages/graphin-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin-components",
-  "version": "2.4.0-siren.11",
+  "version": "2.4.0-siren.12",
   "description": "Components for graphin",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@antv/util": "^2.0.10",
-    "@antv/graphin": "2.6.7-siren.7"
+    "@antv/graphin": "2.6.7-siren.8"
   },
   "peerDependencies": {
     "react": ">=16.9.0",

--- a/packages/graphin-graphscope/package.json
+++ b/packages/graphin-graphscope/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin-graphscope",
-  "version": "1.0.3-siren.10",
+  "version": "1.0.3-siren.11",
   "description": "An Example for GraphScope",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.4.0",
-    "@antv/graphin": "2.6.7-siren.7",
-    "@antv/graphin-components": "2.4.0-siren.11",
-    "@antv/graphin-icons": "1.0.0-siren.11",
+    "@antv/graphin": "2.6.7-siren.8",
+    "@antv/graphin-components": "2.4.0-siren.12",
+    "@antv/graphin-icons": "1.0.0-siren.12",
     "antd": "^4.10.3",
     "classnames": "^2.2.6",
     "re-resizable": "^6.9.0",

--- a/packages/graphin-icons/package.json
+++ b/packages/graphin-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin-icons",
-  "version": "1.0.0-siren.11",
+  "version": "1.0.0-siren.12",
   "description": "graphin icon fonts",
   "main": "./dist/index",
   "scripts": {

--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin",
-  "version": "2.6.7-siren.7",
+  "version": "2.6.7-siren.8",
   "description": "the react toolkit for graph analysis based on g6",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -60,7 +60,7 @@
     "@types/lodash.clonedeep": "^4.5.6",
     "d3-quadtree": "^3.0.1",
     "lodash.clonedeep": "^4.5.0",
-    "@antv/g6": "4.6.15-siren.1"
+    "@antv/g6": "4.6.17-siren.0"
   },
   "peerDependencies": {
     "react": ">=16.9.0",


### PR DESCRIPTION
`tag-2.6.7-siren.8`