### PR TITLE
[INVE-19234] [G6] Edge selected style is not applied

### DIFF
--- a/packages/graphin/src/typings/type.ts
+++ b/packages/graphin/src/typings/type.ts
@@ -330,7 +330,7 @@ export interface EdgeStyle {
     } & CommondAttrsStyle
   >;
   /** 状态样式 */
-  status: Partial<{
+  status?: Partial<{
     selected: Partial<EdgeStyle>;
     hover: Partial<EdgeStyle>;
     disabled: Partial<EdgeStyle>;


### PR DESCRIPTION
Status should be optional on edge styles to make it possible to set status styles by using default edge style. Otherwise, it will just use an empty status object (as it is required param and you need to pass it somehow) if you dont want to recast it.