### PR TITLE
[INVE-19615] Passthrough opacity param for images

### DIFF
--- a/packages/graphin-components/package.json
+++ b/packages/graphin-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin-components",
-  "version": "2.4.0-siren.18",
+  "version": "2.4.0-siren.19",
   "description": "Components for graphin",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@antv/util": "^2.0.10",
-    "@antv/graphin": "2.7.9-siren.0"
+    "@antv/graphin": "2.7.9-siren.1"
   },
   "peerDependencies": {
     "react": ">=16.9.0",

--- a/packages/graphin-graphscope/package.json
+++ b/packages/graphin-graphscope/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin-graphscope",
-  "version": "1.0.3-siren.17",
+  "version": "1.0.3-siren.18",
   "description": "An Example for GraphScope",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.3.0",
-    "@antv/graphin": "2.7.9-siren.0",
-    "@antv/graphin-components": "2.4.0-siren.18",
-    "@antv/graphin-icons": "1.0.0-siren.18",
+    "@antv/graphin": "2.7.9-siren.1",
+    "@antv/graphin-components": "2.4.0-siren.19",
+    "@antv/graphin-icons": "1.0.0-siren.19",
     "antd": "^4.10.3",
     "classnames": "^2.2.6",
     "re-resizable": "^6.9.0",

--- a/packages/graphin-icons/package.json
+++ b/packages/graphin-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin-icons",
-  "version": "1.0.0-siren.18",
+  "version": "1.0.0-siren.19",
   "description": "graphin icon fonts",
   "main": "./dist/index",
   "scripts": {

--- a/packages/graphin/package.json
+++ b/packages/graphin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/graphin",
-  "version": "2.7.9-siren.0",
+  "version": "2.7.9-siren.1",
   "description": "the react toolkit for graph analysis based on g6",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/graphin/src/shape/utils.ts
+++ b/packages/graphin/src/shape/utils.ts
@@ -67,6 +67,9 @@ export const setStatusStyle = (shapes: any, statusStyle: any, parseAttr: (style:
             const { attrs, ...animateOptions } = animate;
             shapeItem.animate(attrs, animateOptions);
           }
+        } else if (otherAttrs.opacity !== undefined) {
+          // Support at least transparency on images
+          shapeItem.attr({ opacity: otherAttrs.opacity });
         }
       }
     });


### PR DESCRIPTION
With this change we can update the opacity of a nodes icon like:

```javascript
const nodes = graph.getNodes();
const model = nodes[0].getModel() as NodeConfig;
 graph.focusItems([nodes[0]], true, true);

if (model && model.style) {
  model.style.icon.opacity = 0.25;
  nodes[0].update(model);
}
```

Before:

https://user-images.githubusercontent.com/2861371/191519727-93d7d64a-05d1-46e1-9fe1-a8d0baa5163f.mp4

After:

https://user-images.githubusercontent.com/2861371/191519735-fad08dd4-4f09-4ad3-8738-fb9b7ab14cef.mp4

